### PR TITLE
Update default perf to be from 2022 instead of 2020

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Change log
 
+##  [0.2.3] - 2021-02-12
+### Updated
+- Update default perf to be from 2022 instead of 2020
+
 ##  [0.2.2] - 2019-06-03
 ### Security
 - Patch security vulnerability in axios

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This tool allows you to easily build **interactive seat selection** into your we
     <script>
       var chartConfig = {
         eventID: '7AB', // demo event
-        perfID: '7AB-7',
+        perfID: '7AB-9',
         selector: '#ingresso-widget',
       }
       var chart = new IngressoSeatingPlan();
@@ -154,7 +154,7 @@ We have a demo user set up, that allows you to create an auth token for our demo
     <script>
       var chartConfig = {
         eventID: '7AB', // demo event
-        perfID: '7AB-7',
+        perfID: '7AB-9',
         selector: '#ingresso-widget',
         token: '<The-X-B2B-Token-From-Before>',
       }

--- a/build/main.min.js
+++ b/build/main.min.js
@@ -136,7 +136,7 @@ function shallowObjectToQueryStringParams(obj) {
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * 
+ *
  */
 
 function makeEmptyFunction(arg) {
@@ -19784,7 +19784,7 @@ module.exports = getActiveElement;
  * LICENSE file in the root directory of this source tree.
  *
  * @typechecks
- * 
+ *
  */
 
 /*eslint-disable no-self-compare */
@@ -19856,7 +19856,7 @@ module.exports = shallowEqual;
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * 
+ *
  */
 
 var isTextNode = __webpack_require__(19);
@@ -20857,7 +20857,7 @@ var App = function (_Component) {
       domain: "https://test.ticketswitch.com",
       // domain: "http://www.dragos-laptop.ingresso.co.uk",
       eventID: "7AB",
-      perfID: "7AB-7",
+      perfID: "7AB-9",
       // eventID: "2GXJ",
       // perfID: "2GXJ-56J",
       chartBackgroundColor: "#F9F9F9",

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -24,7 +24,7 @@ export default class App extends Component {
       domain: "https://test.ticketswitch.com",
       // domain: "http://www.dragos-laptop.ingresso.co.uk",
       eventID: "7AB",
-      perfID: "7AB-7",
+      perfID: "7AB-9",
       // eventID: "2GXJ",
       // perfID: "2GXJ-56J",
       chartBackgroundColor: "#F9F9F9",


### PR DESCRIPTION
The current default perf `7AB-7` is from 2020 and so is no longer available, which makes feather demo not load.