### PR TITLE
Update readme to reference feather v0.4.4 and be more understandable

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,23 +2,24 @@
 
 This tool allows you to easily build **interactive seat selection** into your website and is powered by the Ingresso API.
 
-## Demo:
+## Demo
 
 [Click to view the demo](https://ingresso-group.github.io/feather-demo/)
 
-## Getting Started:
+## Getting Started
 
-1. Create an empty page
+1. Create an empty html file
 
 2. Add a container element, where the widget will appear
 
 3. Import our library at the bottom of your page:
-   [Get it here](https://storage.googleapis.com/ticketswitch/feather/0.4.3/feather.min.js)
+   [Get it here](https://storage.googleapis.com/ticketswitch/feather/0.4.4/feather.min.js)
 
-4. Configure the widget
+4. Configure the widget and initialise the chart
 
-### The least amount of code required to get started:
+5. Open in the browser
 
+### A Simple Example
 ```html
 <!doctype html>
 
@@ -35,12 +36,13 @@ This tool allows you to easily build **interactive seat selection** into your we
   <body>
     <div id="ingresso-widget"></div>
 
-    <script src="https://storage.googleapis.com/ticketswitch/feather/0.4.3/feather.min.js"></script>
+    <script src="https://storage.googleapis.com/ticketswitch/feather/0.4.4/feather.min.js"></script>
     <script>
       var chartConfig = {
         eventID: '7AB', // demo event
         perfID: '7AB-9',
         selector: '#ingresso-widget',
+        token: '<The-X-B2B-Token>' // see the Authentication section below
       }
       var chart = new IngressoSeatingPlan();
       chart.init(chartConfig);
@@ -48,6 +50,41 @@ This tool allows you to easily build **interactive seat selection** into your we
   </body>
 </html>
 ```
+
+![Alt text](example.png?raw=true)
+
+## Authentication
+
+### Getting Authenticated
+
+We have a demo user set up, that allows you to create an auth token for our demo so that you can experiment with the seat chart.
+
+#### 1. Get an auth token
+```bash
+curl https://b2b.ingresso.co.uk/api/b2b/ -u "demo:demopass" -ik
+```
+This will have an `x-b2-b-token` in the response header
+
+#### 2. Add your token to your chart config
+```js
+var chartConfig = {
+  eventID: '7AB', // demo event
+  perfID: '7AB-9',
+  selector: '#ingresso-widget',
+  token: '<The-X-B2B-Token>' // 👈👈👈
+}
+var chart = new IngressoSeatingPlan();
+chart.init(chartConfig);
+```
+
+### Authentication Details
+
+In order to reserve tickets, you need to obtain a username and password. After receiving those, you should make a request to <https://b2b.ingresso.co.uk/api/b2b> with your `username` and `password` in the `Authorization` header, as basic auth. The response will have a custom HTTP Header, **x-b2b-token**. You can then pass this token in the configuration object of the widget, and will allow you to purchase orders based on the **transaction_uuid** value.
+
+Each authentication token has a **maximum** lifetime of 4 hours and is valid for all your customers, so it is advisable that you make this call ahead of time and cache the result, in order to improve the UX of your page (as opposed to making it on each page load). However, this token can get invalidated at any time, which means that you should generate a new one very often (once every few seconds is fine).
+
+**Note:** We are most likely going to change this and move to a model of manually-generated tokens that will have an unlimited lifetime and this would remove the complexity of generating and managing them on your side, but in the meantime, you should use the approach presented above.
+
 
 ## Widget Configuration
 
@@ -120,55 +157,6 @@ If the requested seats happen to have become unavailable before the user can res
 - If they choose to select different seats manually, the modal closes and the initially-selected seats drop off the seating map.
 - If they choose to proceed with the recommended seats, the modal will also close and the app will make a reservation call for the new seats. When this process finishes, the newly-created reservation will be for the recommended seats, which you can then display on your checkout page (or anywhere you choose).
 
-## Authentication
-
-In order to reserve tickets, you need to obtain a username and password. After receiving those, you should make a request to <https://b2b.ingresso.co.uk/api/b2b> with your `username` and `password` in the `Authorization` header, as basic auth. The response will have a custom HTTP Header, **x-b2b-token**. You can then pass this token in the configuration object of the widget, and will allow you to purchase orders based on the **transaction_uuid** value.
-
-Each authentication token has a **maximum** lifetime of 4 hours and is valid for all your customers, so it is advisable that you make this call ahead of time and cache the result, in order to improve the UX of your page (as opposed to making it on each page load). However, this token can get invalidated at any time, which means that you should generate a new one very often (once every few seconds is fine).
-
-**Note:** We are most likely going to change this and move to a model of manually-generated tokens that will have an unlimited lifetime and this would remove the complexity of generating and managing them on your side, but in the meantime, you should use the approach presented above.
-
-## Example with authentication
-
-We have a demo user set up, that allows you to create an auth token for our demo so that you can experiment with the seat chart.
-
-1. Get an Auth Token. `curl https://b2b.ingresso.co.uk/api/b2b/ -u "demo:demopass" -ik`. This will have an `X-B2B-Token` in the response header
-2. Copy paste the code below, inserting your `X-B2B-Token` into the `token` field for the `chartConfig` into a HTML file.
-
-```html
-<!doctype html>
-
-<html>
-  <head>
-    <style>
-      #ingresso-widget {
-        width: 500px;
-        height: 500px;
-      }
-    </style>
-  </head>
-
-  <body>
-    <div id="ingresso-widget"></div>
-
-    <script src="https://storage.googleapis.com/ticketswitch/feather/0.4.3/feather.min.js"></script>
-    <script>
-      var chartConfig = {
-        eventID: '7AB', // demo event
-        perfID: '7AB-9',
-        selector: '#ingresso-widget',
-        token: '<The-X-B2B-Token-From-Before>',
-      }
-      var chart = new IngressoSeatingPlan();
-      chart.init(chartConfig);
-    </script>
-  </body>
-</html>
-```
-
-3. Open the HTML file in a web browser.
-
-![Alt text](example.png?raw=true)
 
 ## Customisation
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ We have a demo user set up, that allows you to create an auth token for our demo
 ```bash
 curl https://b2b.ingresso.co.uk/api/b2b/ -u "demo:demopass" -ik
 ```
-This will have an `x-b2-b-token` in the response header
+This will have a `x-b2b-token` in the response header
 
 #### 2. Add your token to your chart config
 ```js


### PR DESCRIPTION
Also worth noting, when the default URL was `https://test.ticketswitch.com/` the `token` param was optional for the demo because 7AB doesn't require auth, and without a `token` param, access to the event is determined by the `domain`, (in this case https://test.ticketswitch.com/) 's core user (in this case `test`).

I don't think this is ever how it's going to be used and is confusing as hell. So I've removed the the example without the token.